### PR TITLE
fix: default link is valid for onboarding

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,5 @@
 export const ONBOARDING_LINK =
-  process.env.ONBOARDING_LINK || "https://github.com/orgs/hypha-dao/packages";
+  process.env.ONBOARDING_LINK || "https://hyphawallet.page.link/get-hypha-wallet";
 export const AUTHENTICATOR_NAME = "Hypha Wallet";
 export const BUTTON_BACKGROUND_COLOR = "#1D2946";
 export const BUTTON_TEXT_COLOR = "white";


### PR DESCRIPTION
The link that appears with onboarding should be valid

