### PR TITLE
calculating QR size based on image size

### DIFF
--- a/src/web-transport/ui/dialog.js
+++ b/src/web-transport/ui/dialog.js
@@ -108,21 +108,23 @@ class Dialog {
     }
   }
 
-  calculateWrapperBaseSize(esr) {
-    const esrMin = 512;
-    const esrMax = 3000;
-    const newMin = 380;
-    const newMax = 700;
+  getImageSize(dataUrl) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = function() {
+            resolve({ width: this.width, height: this.height });
+        };
+        img.onerror = function() {
+            reject(new Error('Could not load image'));
+        };
+        img.src = dataUrl;
+    });
+}
 
-    let esrLength = esr.length;
-
-    let wrapperBaseSize = (esrLength - esrMin) / (esrMax - esrMin) * (newMax - newMin) + newMin;
-    return Math.max(newMin, Math.min(newMax, wrapperBaseSize)); // Ensure wrapperBaseSize stays within bounds
-  }
-
-  showDialog({ title, text, qrCode, esr, action, footnote }) {
-    const wrapperBaseSize = this.calculateWrapperBaseSize(esr);
-    const qrAreaBaseSize = wrapperBaseSize - 42;
+  async showDialog({ title, text, qrCode, esr, action, footnote }) {
+    const imageSize = await this.getImageSize(qrCode)
+    const qrAreaBaseSize = Math.max(imageSize.width, 380)
+    const wrapperBaseSize = qrAreaBaseSize + 42
 
     this.setupElements(wrapperBaseSize);
 


### PR DESCRIPTION
Fix for #10 

Human Cause (HC): Estimated size for QR code was too small, resulting in garbled QR code display, which the wallet cannot read. 

Fix: Calculating the image size and resizing components to show the full image. 